### PR TITLE
Add CI workflow to build and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Build and Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,19 @@
 /** @type {import('next').NextConfig} */
+const isGithubActions = process.env.GITHUB_ACTIONS === "true"
+const repositoryName = process.env.GITHUB_REPOSITORY?.split("/")[1] ?? ""
+const basePath = isGithubActions && repositoryName ? `/${repositoryName}` : ""
+
 const nextConfig = {
+  output: "export",
+  trailingSlash: true,
   typescript: {
     ignoreBuildErrors: true,
   },
   images: {
     unoptimized: true,
   },
+  basePath,
+  assetPrefix: basePath,
 }
 
 export default nextConfig


### PR DESCRIPTION
### Motivation
- Enable automated builds and deployment of the Next.js app to GitHub Pages on `main` branch pushes and manual dispatch.
- Ensure the app is exported as a static site and served correctly when hosted under a repository path on GitHub Pages.

### Description
- Add a GitHub Actions workflow at `.github/workflows/ci.yml` that checks out the repo, sets up Node.js (`actions/setup-node@v4`), installs dependencies with `npm ci`, runs `npm run build`, uploads the `./out` artifact with `actions/upload-pages-artifact@v3`, and deploys using `actions/deploy-pages@v4` (workflow uses `actions/configure-pages@v5` too). 
- Update `next.config.mjs` to enable static export by setting `output: "export"` and `trailingSlash: true` and to set `basePath` and `assetPrefix` dynamically from the `GITHUB_REPOSITORY` environment when running in GitHub Actions.

### Testing
- Ran `npm run build` locally in this environment, which failed because `next/font` could not fetch Google Fonts; the build error shows failed fetches for `Geist` and `Geist Mono`, so the static `out` artifact was not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c1863ac4832c8337ba38fd1100c8)