### PR TITLE
Add pure Node business-logic tests and enforce them on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Build and Deploy to GitHub Pages
 on:
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:
@@ -33,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run business logic tests
+        run: npm run test:business
+
       - name: Build
         run: npm run build
 
@@ -42,6 +47,7 @@ jobs:
           path: ./out
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "eslint .",
+    "test:business": "node --test --experimental-strip-types tests/business-logic.test.ts",
     "start": "next start"
   },
   "dependencies": {

--- a/tests/business-logic.test.ts
+++ b/tests/business-logic.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { calculateMoxon, formatDimension } from '../lib/moxon-calculator.ts';
+
+const EPSILON = 1e-10;
+
+function assertAlmostEqual(actual: number, expected: number, epsilon = EPSILON) {
+  assert.ok(
+    Math.abs(actual - expected) <= epsilon,
+    `Expected ${actual} to be within ${epsilon} of ${expected}`
+  );
+}
+
+test('calculateMoxon returns null for non-positive inputs', () => {
+  assert.equal(calculateMoxon(0, 1, 'in'), null);
+  assert.equal(calculateMoxon(14.2, 0, 'in'), null);
+  assert.equal(calculateMoxon(-14.2, 1, 'in'), null);
+});
+
+test('calculateMoxon maintains core geometry relationships', () => {
+  const result = calculateMoxon(14.2, 2.5, 'mm');
+  assert.ok(result);
+
+  const { dimensions } = result;
+  assertAlmostEqual(dimensions.e, dimensions.b + dimensions.c + dimensions.d);
+  assertAlmostEqual(dimensions.drivenCutLength, dimensions.a + 2 * dimensions.b);
+  assertAlmostEqual(dimensions.reflectorCutLength, dimensions.a + 2 * dimensions.d);
+});
+
+test('insulated wire applies velocity factor scaling to wavelength dimensions', () => {
+  const bare = calculateMoxon(14.2, 1.5, 'mm', false);
+  const insulated = calculateMoxon(14.2, 1.5, 'mm', true);
+
+  assert.ok(bare);
+  assert.ok(insulated);
+  assert.equal(insulated.velocityFactor, 0.97);
+
+  const keys = ['a', 'b', 'c', 'd', 'e', 'drivenCutLength', 'reflectorCutLength'] as const;
+  for (const key of keys) {
+    assertAlmostEqual(insulated.dimensions[key], bare.dimensions[key] * insulated.velocityFactor);
+  }
+});
+
+test('converted output units are internally consistent', () => {
+  const result = calculateMoxon(14.2, 2.0, 'mm');
+  assert.ok(result);
+
+  const wl = result.converted.wl;
+  const inches = result.converted.in;
+  const feet = result.converted.ft;
+
+  assertAlmostEqual(wl.a * wl.wavelength, wl.a);
+  assertAlmostEqual(inches.a / inches.wavelength, wl.a);
+  assertAlmostEqual(feet.a / feet.wavelength, wl.a);
+});
+
+test('warning message appears for extremely small and large wire diameters', () => {
+  const verySmall = calculateMoxon(14.2, 1e-7, 'wl');
+  const veryLarge = calculateMoxon(14.2, 0.02, 'wl');
+
+  assert.ok(verySmall?.dimensions.warning?.includes('very small'));
+  assert.ok(veryLarge?.dimensions.warning?.includes('very large'));
+});
+
+test('awg input matches equivalent inch input', () => {
+  const awg = 12;
+  const diameterInches = 0.005 * Math.pow(92, (36 - awg) / 39);
+
+  const fromAwg = calculateMoxon(28.5, awg, 'awg');
+  const fromInches = calculateMoxon(28.5, diameterInches, 'in');
+
+  assert.ok(fromAwg);
+  assert.ok(fromInches);
+  assertAlmostEqual(fromAwg.dimensions.wireDiameterWl, fromInches.dimensions.wireDiameterWl);
+});
+
+test('formatDimension uses fixed and exponential display modes correctly', () => {
+  assert.equal(formatDimension(1.23456, 2), '1.23');
+  assert.equal(formatDimension(0.0005, 2), '5.00e-4');
+});


### PR DESCRIPTION
### Motivation
- Provide a small, dependency-free test layer that validates the core Moxon calculator business rules. 
- Ensure those invariants run automatically on every PR targeting `main` to catch regressions early. 
- Keep the test harness minimal by using only Node's built-in test runner and assertion library.

### Description
- Add `tests/business-logic.test.ts` which uses `node:test` and `node:assert` to cover input guards, geometry invariants, insulation scaling, unit conversion consistency, warning thresholds, AWG conversion parity, and formatting behavior. 
- Add an npm script `test:business` that runs the suite with `node --test --experimental-strip-types tests/business-logic.test.ts`. 
- Update CI (`.github/workflows/ci.yml`) to trigger on `pull_request` to `main` and to run the business logic tests before the build step. 
- Gate the deploy job so it only runs on push events to the `main` branch.

### Testing
- Ran the new suite locally with `npm run test:business`, and all tests passed (7/7) under Node 22. 
- The CI workflow was updated to execute `npm run test:business` during PR validation so the same tests will run on every PR to `main`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c23c2d48832c9d739bc282c56f87)