### PR TITLE
Refine CI so Pages deploys only on main merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: Build and Deploy to GitHub Pages
+name: CI and GitHub Pages Deploy
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
+    branches: ["main"]
+  push:
     branches: ["main"]
   workflow_dispatch:
 
@@ -17,8 +17,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run business logic tests
+        run: npm run test:business
+
+  build:
+    name: Build static site
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,9 +57,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run business logic tests
-        run: npm run test:business
-
       - name: Build
         run: npm run build
 
@@ -47,6 +66,7 @@ jobs:
           path: ./out
 
   deploy:
+    name: Deploy to GitHub Pages
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages


### PR DESCRIPTION
### Motivation
- Prevent GitHub Pages publishing during PR validation by ensuring deploy steps run only after a merge to `main`.
- Provide a dedicated, visible test status that can be required by branch protection to block merging when tests fail.
- Separate concerns so CI for PR validation remains fast and safe while full publish runs only on main.

### Description
- Updated ` .github/workflows/ci.yml` to split the pipeline into a `tests` job and separate `build`/`deploy` jobs.
- Added job-level conditions so `build` and `deploy` run only when `github.event_name == 'push' && github.ref == 'refs/heads/main'` and made `build` depend on `tests` via `needs: tests`.
- Kept running tests on PRs to `main` while preventing Pages artifact upload/deploy during PR events.

### Testing
- Ran `npm run test:business` in the repository and the test suite completed successfully with all tests passing.
- Validated the updated workflow file at ` .github/workflows/ci.yml` for the intended job ordering and `if` conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c4264cf0832ca3b622ee90e07674)