### PR TITLE
Disable Vercel analytics and fix 3D preview font loading

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,8 +46,8 @@
 }
 
 @theme inline {
-  --font-sans: 'Geist', 'Geist Fallback';
-  --font-mono: 'Geist Mono', 'Geist Mono Fallback';
+  --font-sans: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,6 @@
 import React from "react"
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
-import { Analytics } from '@vercel/analytics/next'
 import './globals.css'
-
-const _geist = Geist({ subsets: ["latin"] });
-const _geistMono = Geist_Mono({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: 'Moxon Antenna Calculator',
@@ -39,7 +34,6 @@ export default function RootLayout({
     <html lang="en">
       <body className={`font-sans antialiased`}>
         {children}
-        <Analytics />
       </body>
     </html>
   )

--- a/components/moxon-3d-preview.tsx
+++ b/components/moxon-3d-preview.tsx
@@ -66,7 +66,6 @@ function FrameMesh({
         color="#94a3b8"
         anchorX="center"
         anchorY="top"
-        font="/fonts/GeistMono-Regular.ttf"
       >
         {`A = ${dims.a.toFixed(1)} mm`}
       </Text>
@@ -76,7 +75,6 @@ function FrameMesh({
         color="#94a3b8"
         anchorX="left"
         anchorY="middle"
-        font="/fonts/GeistMono-Regular.ttf"
       >
         {`E = ${dims.e.toFixed(1)} mm`}
       </Text>
@@ -88,7 +86,6 @@ function FrameMesh({
         color="#64748b"
         anchorX="center"
         anchorY="middle"
-        font="/fonts/Geist-Regular.ttf"
       >
         {"Direction of radiation \u2192"}
       </Text>
@@ -104,7 +101,6 @@ function EmptyState() {
       color="#64748b"
       anchorX="center"
       anchorY="middle"
-      font="/fonts/Geist-Regular.ttf"
     >
       Enter valid parameters to preview
     </Text>


### PR DESCRIPTION
### Motivation
- The app was failing to render the 3D/STL preview due to missing hosted TTF fonts and produced console errors from Vercel Web Analytics script fetches. 
- External Google Fonts usage during build made the production build unreliable in constrained environments.

### Description
- Removed `@vercel/analytics/next` import and the `<Analytics />` element from `app/layout.tsx` to stop injecting Vercel analytics scripts. 
- Removed `next/font/google` Geist font usage from `app/layout.tsx` so fonts are no longer fetched from Google during build. 
- Replaced Geist font tokens with local/system font stacks in `app/globals.css` to avoid external font fetches. 
- Removed explicit `/fonts/Geist*.ttf` `font` props from `<Text />` elements in `components/moxon-3d-preview.tsx` so the 3D preview no longer attempts to load missing TTF assets at runtime.

### Testing
- Ran `npm run test:business` and all tests passed. 
- Ran `npm run build` and the production build now succeeds after removing external font fetches. 
- Ran `npm run lint` which failed because the repository lacks an ESLint flat config (`eslint.config.js|mjs|cjs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c560f814832c8f5cbea6610969fe)