### PR TITLE
Add GitHub Actions PR preview build artifacts

### DIFF
--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -1,0 +1,43 @@
+name: PR Preview Build
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preview-build:
+    name: Build preview artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build app
+        run: npm run build
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextjs-preview-${{ github.event.pull_request.number || github.run_number }}
+          path: |
+            .next
+            public
+            package.json
+            package-lock.json
+            next.config.mjs
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ The app defaults to an EU868 Meshtastic example (869.525 MHz, 1.38 mm conductor)
 - `lib/moxon-stl-generator.ts` – binary STL generation utilities
 - `components/` – form, diagram, results table, and 3D preview components
 
+## PR Build Previews
+
+Every pull request targeting `main` now triggers the **PR Preview Build** GitHub Actions workflow.
+
+It will:
+- install dependencies
+- run a production `next build`
+- upload a downloadable build artifact (`nextjs-preview-<pr-number>`)
+
+Use this artifact to verify that the app builds successfully before merging.
+
 ## Notes
 
 - This tool helps with dimensioning and prototyping; real-world performance still depends on materials, assembly quality, nearby objects, and tuning/measurement.


### PR DESCRIPTION
### Motivation

- Provide per-PR build previews so contributors can verify the app builds successfully before merging to `main`. 
- Make a downloadable artifact available for manual inspection of the production `next build` output.

### Description

- Add `.github/workflows/pr-preview-build.yml` which triggers on `pull_request` to `main` and `workflow_dispatch`, checks out the repo, sets up Node.js 20, runs `npm ci` and `npm run build`, and uploads a `nextjs-preview-<pr-number>` artifact containing `.next`, `public`, `package.json`, `package-lock.json`, and `next.config.mjs`.
- Update `README.md` with a `PR Build Previews` section documenting the workflow and how to use the uploaded artifact.

### Testing

- Ran `npm ci` which completed successfully.
- Ran `npm run test:business` which executed 7 tests and all passed.
- Ran `npm run build` which completed a successful Next.js production build and generated static pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1cac94028832cac1c3d5c489850b4)