### PR TITLE
Add advanced wire material and sleeved-wire parameters

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import { MoxonResultsTable } from "@/components/moxon-results-table";
 import { UnitSelector } from "@/components/unit-selector";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { calculateMoxon } from "@/lib/moxon-calculator";
-import type { DiameterUnit, OutputUnit } from "@/lib/moxon-calculator";
+import type { DiameterUnit, OutputUnit, WireMaterial } from "@/lib/moxon-calculator";
 import { AlertCircle, Radio, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -27,7 +27,8 @@ export default function MoxonCalculator() {
   const [wireDiameter, setWireDiameter] = useState("1.38");
   const [diameterUnit, setDiameterUnit] = useState<DiameterUnit>("mm");
   const [displayUnit, setDisplayUnit] = useState<OutputUnit>("mm");
-  const [isInsulated, setIsInsulated] = useState(false);
+  const [isSleeved, setIsSleeved] = useState(false);
+  const [wireMaterial, setWireMaterial] = useState<WireMaterial>("copper");
 
   // Calculate results
   const results = useMemo(() => {
@@ -38,8 +39,8 @@ export default function MoxonCalculator() {
       return null;
     }
 
-    return calculateMoxon(freq, diam, diameterUnit, isInsulated);
-  }, [frequency, wireDiameter, diameterUnit, isInsulated]);
+    return calculateMoxon(freq, diam, diameterUnit, isSleeved, wireMaterial);
+  }, [frequency, wireDiameter, diameterUnit, isSleeved, wireMaterial]);
 
   const isValid = results !== null;
 
@@ -64,7 +65,8 @@ export default function MoxonCalculator() {
     setFrequency("869.525");
     setWireDiameter("1.38");
     setDiameterUnit("mm");
-    setIsInsulated(false);
+    setIsSleeved(false);
+    setWireMaterial("copper");
   };
 
   return (
@@ -108,8 +110,10 @@ export default function MoxonCalculator() {
               setWireDiameter={setWireDiameter}
               diameterUnit={diameterUnit}
               setDiameterUnit={setDiameterUnit}
-              isInsulated={isInsulated}
-              setIsInsulated={setIsInsulated}
+              isSleeved={isSleeved}
+              setIsSleeved={setIsSleeved}
+              wireMaterial={wireMaterial}
+              setWireMaterial={setWireMaterial}
             />
           </div>
         </section>
@@ -195,7 +199,7 @@ export default function MoxonCalculator() {
             </ul>
             <p className="pt-1 border-t border-border mt-1">
               Default: EU868 Meshtastic (869.525 MHz) with H07V-U 1.5 mm&#178; solid copper wire (bare conductor diameter 1.38 mm).
-              Toggle "insulated" if you keep the PVC jacket on.
+              Use Advanced wire settings for copper vs stainless and sleeved wire compensation.
             </p>
           </div>
         </section>

--- a/components/moxon-input-form.tsx
+++ b/components/moxon-input-form.tsx
@@ -10,8 +10,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import type { DiameterUnit } from "@/lib/moxon-calculator";
-import { diameterUnitLabels } from "@/lib/moxon-calculator";
+import type { DiameterUnit, WireMaterial } from "@/lib/moxon-calculator";
+import { diameterUnitLabels, wireMaterialLabels } from "@/lib/moxon-calculator";
 
 interface MoxonInputFormProps {
   frequency: string;
@@ -20,8 +20,10 @@ interface MoxonInputFormProps {
   setWireDiameter: (value: string) => void;
   diameterUnit: DiameterUnit;
   setDiameterUnit: (value: DiameterUnit) => void;
-  isInsulated: boolean;
-  setIsInsulated: (value: boolean) => void;
+  isSleeved: boolean;
+  setIsSleeved: (value: boolean) => void;
+  wireMaterial: WireMaterial;
+  setWireMaterial: (value: WireMaterial) => void;
 }
 
 export function MoxonInputForm({
@@ -31,12 +33,13 @@ export function MoxonInputForm({
   setWireDiameter,
   diameterUnit,
   setDiameterUnit,
-  isInsulated,
-  setIsInsulated,
+  isSleeved,
+  setIsSleeved,
+  wireMaterial,
+  setWireMaterial,
 }: MoxonInputFormProps) {
   return (
     <div className="flex flex-col gap-5">
-      {/* Frequency Input */}
       <div className="flex flex-col gap-2">
         <Label htmlFor="frequency" className="text-sm font-medium text-foreground">
           Frequency (MHz)
@@ -52,12 +55,9 @@ export function MoxonInputForm({
           min="0"
           step="any"
         />
-        <p className="text-xs text-muted-foreground">
-          Center frequency for your antenna design
-        </p>
+        <p className="text-xs text-muted-foreground">Center frequency for your antenna design</p>
       </div>
 
-      {/* Wire Diameter Input */}
       <div className="flex flex-col gap-2">
         <Label htmlFor="diameter" className="text-sm font-medium text-foreground">
           Wire Diameter (conductor only)
@@ -96,22 +96,46 @@ export function MoxonInputForm({
         </p>
       </div>
 
-      {/* Insulated Wire Toggle */}
-      <div className="flex items-center justify-between rounded-lg border border-border p-4">
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="insulated-toggle" className="text-sm font-medium text-foreground">
-            Insulated wire (PVC)
-          </Label>
-          <p className="text-xs text-muted-foreground">
-            Uses 0.97 velocity factor. At 868 MHz, shorten cuts 1–2 mm for tuning.
-          </p>
+      <details className="rounded-lg border border-border p-4">
+        <summary className="cursor-pointer text-sm font-medium text-foreground">Advanced wire settings</summary>
+        <div className="mt-4 flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="wire-material" className="text-sm font-medium text-foreground">
+              Conductor material
+            </Label>
+            <Select
+              value={wireMaterial}
+              onValueChange={(v) => setWireMaterial(v as WireMaterial)}
+            >
+              <SelectTrigger id="wire-material" className="h-12 bg-input border-border">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(Object.keys(wireMaterialLabels) as WireMaterial[]).map((material) => (
+                  <SelectItem key={material} value={material}>
+                    {wireMaterialLabels[material]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Stainless steel uses a small correction compared to copper.
+            </p>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-border p-4">
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="sleeved-toggle" className="text-sm font-medium text-foreground">
+                Sleeved wire (PVC)
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Uses a 0.97 velocity-factor correction when insulation sleeve stays on the wire.
+              </p>
+            </div>
+            <Switch id="sleeved-toggle" checked={isSleeved} onCheckedChange={setIsSleeved} />
+          </div>
         </div>
-        <Switch
-          id="insulated-toggle"
-          checked={isInsulated}
-          onCheckedChange={setIsInsulated}
-        />
-      </div>
+      </details>
     </div>
   );
 }

--- a/components/moxon-results-table.tsx
+++ b/components/moxon-results-table.tsx
@@ -120,9 +120,11 @@ export function MoxonResultsTable({ results, displayUnit, frequencyMHz, wireDiam
             </span>
           </div>
         </div>
-        {results.isInsulated && (
+        {results.velocityFactor < 1 && (
           <p className="text-xs text-accent">
-            Lengths include {((1 - results.velocityFactor) * 100).toFixed(0)}% velocity-factor correction for insulated wire.
+            Lengths include {((1 - results.velocityFactor) * 100).toFixed(1)}% total correction for
+            {" "}{results.wireMaterial === "stainless" ? "stainless steel" : "copper"}
+            {results.isSleeved ? " sleeved wire" : " bare wire"}.
           </p>
         )}
       </div>

--- a/tests/business-logic.test.ts
+++ b/tests/business-logic.test.ts
@@ -28,18 +28,29 @@ test('calculateMoxon maintains core geometry relationships', () => {
   assertAlmostEqual(dimensions.reflectorCutLength, dimensions.a + 2 * dimensions.d);
 });
 
-test('insulated wire applies velocity factor scaling to wavelength dimensions', () => {
+test('sleeved wire applies velocity factor scaling to wavelength dimensions', () => {
   const bare = calculateMoxon(14.2, 1.5, 'mm', false);
-  const insulated = calculateMoxon(14.2, 1.5, 'mm', true);
+  const sleeved = calculateMoxon(14.2, 1.5, 'mm', true);
 
   assert.ok(bare);
-  assert.ok(insulated);
-  assert.equal(insulated.velocityFactor, 0.97);
+  assert.ok(sleeved);
+  assert.equal(sleeved.velocityFactor, 0.97);
 
   const keys = ['a', 'b', 'c', 'd', 'e', 'drivenCutLength', 'reflectorCutLength'] as const;
   for (const key of keys) {
-    assertAlmostEqual(insulated.dimensions[key], bare.dimensions[key] * insulated.velocityFactor);
+    assertAlmostEqual(sleeved.dimensions[key], bare.dimensions[key] * sleeved.velocityFactor);
   }
+});
+
+test('stainless material applies additional shortening compared to copper', () => {
+  const copper = calculateMoxon(14.2, 1.5, 'mm', false, 'copper');
+  const stainless = calculateMoxon(14.2, 1.5, 'mm', false, 'stainless');
+
+  assert.ok(copper);
+  assert.ok(stainless);
+  assert.equal(copper.velocityFactor, 1);
+  assert.equal(stainless.velocityFactor, 0.992);
+  assert.ok(stainless.dimensions.a < copper.dimensions.a);
 });
 
 test('converted output units are internally consistent', () => {


### PR DESCRIPTION
### Motivation
- Users need to account for conductor material and whether the wire remains sleeved when calculating Moxon dimensions because copper vs stainless and sleeved (PVC) insulation affect effective electrical length. 
- The calculator previously hardcoded a single insulated correction and didn't expose material choices that hobbyists commonly use.

### Description
- Add `WireMaterial` type and `wireMaterial` / `isSleeved` fields to the calculation result and app state, and expose `wireMaterialLabels` for the UI (`lib/moxon-calculator.ts`, `components/moxon-input-form.tsx`).
- Introduce `MATERIAL_CORRECTION_FACTOR` and `SLEEVED_VELOCITY_FACTOR` and apply them multiplicatively in `calculateMoxon` to compute a combined `velocityFactor` used to scale geometry (`lib/moxon-calculator.ts`).
- Add an "Advanced wire settings" UI with a conductor material selector (`Copper` / `Stainless steel`) and a sleeved-wire toggle, and wire these controls through `app/page.tsx` into `calculateMoxon` (`components/moxon-input-form.tsx`, `app/page.tsx`).
- Update results messaging in `MoxonResultsTable` to report the combined correction percent and to name the selected material and whether the wire is sleeved, and extend business tests to cover stainless-vs-copper behavior (`components/moxon-results-table.tsx`, `tests/business-logic.test.ts`).

### Testing
- Ran unit/business tests with `npm run test:business`, and all tests passed (8/8).
- Built the app with `npm run build`, and the production build completed successfully.
- Ran `npm run lint`, which failed due to the repository missing an ESLint v9 configuration file (ESLint requires `eslint.config.(js|mjs|cjs)`), so linting is reported but not blocking the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a200abf6cc832cb27b28fe2281ee72)