### PR TITLE
docs: expand and clarify Moxon calculation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,97 @@ It provides:
 - 2D diagram + interactive 3D preview
 - One-click export of a **3D-printable STL frame** for building
 
+## Calculation Method (Deep Dive)
+
+This project implements a **Cebik-style polynomial method** to estimate practical Moxon rectangle dimensions from two primary inputs:
+
+1. Operating frequency in MHz
+2. Conductor diameter (mm, inches, AWG, or wavelengths)
+
+### 1) Convert to electrical diameter
+
+The original formulas are based on conductor diameter in **wavelengths** (`dw`), so all diameter inputs are normalized first:
+
+- `dw = diameter / wavelength_in_same_units`
+- with `wavelength = c / f` expressed in feet, inches, meters, or millimeters per MHz
+
+For AWG input, we first convert gauge to diameter in inches:
+
+- `diameter_in = 0.005 * 92^((36 - AWG) / 39)`
+
+Then convert inches to wavelengths.
+
+### 2) Use `log10(dw)` as the polynomial variable
+
+The Cebik fit equations use base-10 logarithm of electrical diameter:
+
+- `x = log10(dw)`
+
+In code this is computed via natural log as:
+
+- `x = 0.4342945 * ln(dw)`
+
+### 3) Evaluate fitted geometry equations
+
+The app calculates the four primary geometry terms in wavelengths (`A`, `B`, `C`, `D`) using the fitted coefficients:
+
+- `A = -0.0008571428571*x^2 - 0.009571428571*x + 0.3398571429`
+- `B = -0.002142857143*x^2 - 0.02035714286*x + 0.008285714286`
+- `C =  0.001809523381*x^2 + 0.01780952381*x + 0.05164285714`
+- `D =  0.001*x + 0.07178571429`
+
+Where:
+
+- `A`: full horizontal element span
+- `B`: driven element bent tail length
+- `C`: inner gap between tip ends
+- `D`: reflector bent tail length
+
+Then the total depth is derived:
+
+- `E = B + C + D`
+
+### 4) Apply practical build correction factors
+
+After the baseline geometry is computed, dimensions are scaled by a combined factor:
+
+- `velocityFactor = sleeveFactor * materialFactor`
+
+Current defaults:
+
+- sleeve off: `1.0`
+- sleeve on: `0.97`
+- copper material: `1.0`
+- stainless material: `0.992`
+
+This keeps the model practical for common hobby builds where insulation and conductor choice can shift effective electrical length.
+
+### 5) Compute cut lengths
+
+To support construction directly, the app computes total conductor lengths to cut:
+
+- Driven element: `A + 2*B`
+- Reflector element: `A + 2*D`
+
+These are reported in all output unit systems.
+
+### 6) Convert wavelengths to requested units
+
+Each wavelength-domain result is multiplied by one-wavelength length at the chosen frequency:
+
+- feet: `983.5592 / f_MHz`
+- inches: `11802.71 / f_MHz`
+- meters: `299.7925 / f_MHz`
+- millimeters: `299792.5 / f_MHz`
+
+This allows exact unit switching in UI without recomputing the core geometry.
+
+### Validity and reliability notes
+
+- The model is very fast and ideal for first-pass design and printable fixtures.
+- A warning is emitted when `log10(dw)` falls outside a practical range (`< -6` or `> -2`), since extrapolated polynomial fits may become less reliable.
+- Real-world resonance still depends on nearby materials, construction accuracy, feed arrangement, and installation environment. Final trimming and measurement (e.g., VNA/SWR) are recommended.
+
 ## Features
 
 - **Cebik-based geometry math** for Moxon dimensions.

--- a/lib/moxon-calculator.ts
+++ b/lib/moxon-calculator.ts
@@ -1,6 +1,26 @@
-// Moxon antenna dimension calculator
-// Based on algorithm by L.B. Cebik, W4RNL
-// http://www.cebik.com/moxon/moxgen.html
+/**
+ * Moxon antenna dimension calculator.
+ *
+ * Method reference
+ * ----------------
+ * The geometry calculation implemented here follows the polynomial-fit approach
+ * popularized by L.B. Cebik (W4RNL) in the original Moxon rectangle calculator.
+ *
+ * Why polynomial fits?
+ * - A Moxon rectangle can be defined by 5 key dimensions (A..E) once frequency and
+ *   conductor diameter are known.
+ * - Cebik's method uses empirically derived equations that map the conductor
+ *   electrical diameter (in wavelengths) to each geometry term.
+ * - Those equations are fast, deterministic, and suitable for instant UI feedback.
+ *
+ * Scope of this module
+ * --------------------
+ * 1) Normalize wire diameter into electrical units (wavelength fraction).
+ * 2) Evaluate Cebik polynomial equations for A/B/C/D.
+ * 3) Apply practical correction factors (insulation + material).
+ * 4) Derive E and cut-length values from A/B/C/D.
+ * 5) Convert all wavelength outputs into common linear units.
+ */
 
 export type DiameterUnit = "in" | "mm" | "awg" | "wl";
 export type OutputUnit = "wl" | "ft" | "in" | "m" | "mm";
@@ -41,23 +61,51 @@ export interface MoxonResults {
   };
 }
 
-// Conversion factors
+/**
+ * Wavelength conversion constants expressed per MHz.
+ *
+ * Example:
+ * wavelength_ft = SPEED_OF_LIGHT_FT / frequencyMHz
+ *
+ * These constants are rounded practical values commonly used in amateur radio
+ * calculators, trading tiny theoretical precision for consistency and usability.
+ */
 const SPEED_OF_LIGHT_FT = 983.5592; // feet per MHz wavelength
 const SPEED_OF_LIGHT_IN = 11802.71; // inches per MHz wavelength
 const SPEED_OF_LIGHT_M = 299.7925; // meters per MHz wavelength
 const SPEED_OF_LIGHT_MM = 299792.5; // mm per MHz wavelength
 
-// Material correction is a practical tuning offset for common hobby wire choices.
-// Copper is the baseline used by most calculators.
+/**
+ * Material correction factor.
+ *
+ * This app treats copper as baseline (factor = 1). Stainless is modeled as a
+ * slight electrical shortening for the same physical geometry, therefore a
+ * small down-scaling factor is applied.
+ *
+ * NOTE: This is a practical approximation, not a full electromagnetic material
+ * model. Final tuning in the built environment is still recommended.
+ */
 const MATERIAL_CORRECTION_FACTOR: Record<WireMaterial, number> = {
   copper: 1,
   stainless: 0.992,
 };
 
-// Velocity factor for sleeved (PVC-insulated) wire
+/**
+ * Velocity factor for sleeved (insulated) wire.
+ *
+ * Insulation increases effective electrical length, so physical elements are
+ * often shortened by a factor near 0.95-0.98. We use 0.97 as a pragmatic
+ * default suitable for many PVC-insulated builds.
+ */
 const SLEEVED_VELOCITY_FACTOR = 0.97;
 
-// Convert wire diameter to wavelengths
+/**
+ * Convert conductor diameter into wavelengths.
+ *
+ * The Cebik equations are parameterized by electrical diameter (dw), not by
+ * raw metric/imperial units. Therefore every input path is normalized to a
+ * wavelength fraction before geometry equations are evaluated.
+ */
 function convertToWavelengths(
   diameter: number,
   unit: DiameterUnit,
@@ -71,7 +119,7 @@ function convertToWavelengths(
     case "mm":
       return diameter / (SPEED_OF_LIGHT_MM / frequencyMHz);
     case "awg": {
-      // AWG to inches conversion
+      // AWG -> inches: standard logarithmic wire-gauge relation.
       const diameterInches = 0.005 * Math.pow(92, (36 - diameter) / 39);
       return diameterInches / (SPEED_OF_LIGHT_IN / frequencyMHz);
     }
@@ -80,7 +128,25 @@ function convertToWavelengths(
   }
 }
 
-// Calculate Moxon dimensions based on Cebik's algorithm
+/**
+ * Compute Moxon rectangle dimensions for a given frequency and wire diameter.
+ *
+ * Step-by-step method:
+ * 1) Validate numeric safety (avoid log(<=0) and divide-by-zero paths).
+ * 2) Convert wire diameter to wavelengths: dw.
+ * 3) Compute log10(dw), the independent variable used by Cebik's fitted curves.
+ * 4) Evaluate polynomial equations for A/B/C and linear equation for D.
+ * 5) Apply multiplicative correction factors:
+ *      finalFactor = sleevedFactor * materialFactor
+ * 6) Derive secondary dimensions:
+ *      E = B + C + D
+ *      drivenCut = A + 2*B
+ *      reflectorCut = A + 2*D
+ * 7) Convert wavelength outputs to ft/in/m/mm using frequency-derived scale.
+ *
+ * Returned dimensions are always exposed both in wavelengths and converted units
+ * so UI consumers can switch representation without recalculating geometry.
+ */
 export function calculateMoxon(
   frequencyMHz: number,
   wireDiameter: number,
@@ -96,7 +162,7 @@ export function calculateMoxon(
   // Convert wire diameter to wavelengths
   const dw = convertToWavelengths(wireDiameter, diameterUnit, frequencyMHz);
 
-  // log base 10 of wire diameter in wavelengths
+  // log10(dw): Cebik formulas are functions of this value.
   const log10Diameter = 0.4342945 * Math.log(dw);
 
   // Check for warnings
@@ -107,7 +173,13 @@ export function calculateMoxon(
     warning = "Wire diameter very large for this frequency — results may be unreliable.";
   }
 
-  // Calculate dimensions in wavelengths using Cebik's polynomial formulas
+  /**
+   * Polynomial coefficients (A, B, C) and linear fit (D).
+   *
+   * These are direct numeric fits from the classic Cebik calculator lineage.
+   * The outputs are dimension fractions in wavelengths before practical
+   * correction factors are applied.
+   */
   let a =
     -0.0008571428571 * log10Diameter * log10Diameter +
     -0.009571428571 * log10Diameter +
@@ -125,7 +197,7 @@ export function calculateMoxon(
 
   let d = 0.001 * log10Diameter + 0.07178571429;
 
-  // Apply wire corrections
+  // Apply build-practical corrections as a single multiplicative factor.
   const sleevedFactor = isSleeved ? SLEEVED_VELOCITY_FACTOR : 1.0;
   const materialFactor = MATERIAL_CORRECTION_FACTOR[wireMaterial];
   const velocityFactor = sleevedFactor * materialFactor;
@@ -136,11 +208,11 @@ export function calculateMoxon(
 
   const e = b + c + d;
 
-  // Calculate cut lengths (total wire to cut from spool)
+  // Calculate cut lengths (total conductor to cut from spool before forming).
   const drivenCutLength = a + 2 * b;
   const reflectorCutLength = a + 2 * d;
 
-  // Wavelength conversion factors
+  // Frequency-specific conversion factors from wavelength units.
   const wlToFt = SPEED_OF_LIGHT_FT / frequencyMHz;
   const wlToIn = SPEED_OF_LIGHT_IN / frequencyMHz;
   const wlToM = SPEED_OF_LIGHT_M / frequencyMHz;
@@ -159,6 +231,11 @@ export function calculateMoxon(
     warning,
   };
 
+  /**
+   * Convert wavelength-based geometry into a linear output unit.
+   *
+   * factor = length of one wavelength in target unit at this frequency.
+   */
   function convert(factor: number): ConvertedDimensions {
     return {
       a: a * factor,


### PR DESCRIPTION
### Motivation

- Make the implemented Moxon geometry algorithm auditable by documenting the math and assumptions used to compute A/B/C/D/E from frequency and conductor diameter. 
- Surface practical engineering choices (insulation velocity factor, material correction, unit conversions) so contributors and builders understand why results may differ from raw EM simulation. 
- Reduce onboarding friction for future maintenance by placing rationale next to the calculation code.

### Description

- Add a comprehensive "Calculation Method (Deep Dive)" section to `README.md` that describes the full pipeline including electrical diameter normalization, `log10(dw)` transform, the Cebik polynomial fits for `A/B/C/D`, cut-length formulas, correction factors, unit conversion constants, and reliability notes. 
- Expand inline documentation in `lib/moxon-calculator.ts` with module-level and function-level docblocks explaining the method, conversion constants, AWG conversion, polynomial intent, correction-factor application, and conversion helper semantics. 
- Keep runtime behavior unchanged (no algorithmic changes), only clarifying code comments and documentation to improve maintainability and traceability. 

### Testing

- Ran `npm run test:business` and all tests passed (8/8). 
- Ran `npm run lint` which completed with no errors but reported pre-existing warnings unrelated to these documentation changes. 
- Files changed: `README.md` and `lib/moxon-calculator.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fba7895c832ca7c95e221e16170d)